### PR TITLE
Add basic stubs to python modules

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -7,3 +7,8 @@ This folder contains all modular logic for handling signals and UI inside TouchD
 - `osc_utils.py`: Helper functions for sending/receiving OSC messages.
 - `ui_callbacks.py`: Logic for UI button presses, dropdowns, etc.
 - `stage_utils.py`: (Planned) Utilities for 3D stage modeling and projection mapping.
+
+Each module currently exposes small stub classes or functions so new
+contributors can experiment with the system without writing everything
+from scratch. These stubs print basic information to the console and
+serve as starting points for future development.

--- a/src/input_handlers.py
+++ b/src/input_handlers.py
@@ -1,0 +1,39 @@
+"""Input parsing for incoming OSC and MIDI signals.
+
+This module provides minimal stub classes used by the TouchDesigner project.
+Actual implementations will be filled in during development.
+"""
+
+from typing import Any
+
+
+class InputHandler:
+    """Basic handler for OSC and MIDI messages."""
+
+    def handle_osc(self, address: str, *args: Any) -> None:
+        """Handle an incoming OSC message.
+
+        Parameters
+        ----------
+        address:
+            OSC address pattern of the message.
+        *args:
+            Message payload values.
+        """
+        # Placeholder implementation
+        print(f"Received OSC: {address} {args}")
+
+    def handle_midi(self, channel: int, control: int, value: int) -> None:
+        """Handle an incoming MIDI message.
+
+        Parameters
+        ----------
+        channel:
+            MIDI channel number.
+        control:
+            Controller or note number.
+        value:
+            Associated value or velocity.
+        """
+        # Placeholder implementation
+        print(f"Received MIDI: ch={channel} ctrl={control} val={value}")

--- a/src/osc_utils.py
+++ b/src/osc_utils.py
@@ -1,0 +1,29 @@
+"""Utility functions for Open Sound Control communication."""
+
+from typing import Any, Iterable
+
+
+class OSCClient:
+    """Very small placeholder OSC client."""
+
+    def __init__(self, host: str = "127.0.0.1", port: int = 8000) -> None:
+        self.host = host
+        self.port = port
+
+    def send(self, address: str, *args: Any) -> None:
+        """Pretend to send an OSC message to the configured host/port."""
+        msg = f"OSC -> {self.host}:{self.port} {address} {args}"
+        print(msg)
+
+
+def bundle(messages: Iterable[tuple[str, tuple[Any, ...]]]) -> None:
+    """Send a bundle of OSC messages.
+
+    Parameters
+    ----------
+    messages:
+        Iterable of tuples in the form ``(address, args)``.
+    """
+    client = OSCClient()
+    for addr, args in messages:
+        client.send(addr, *args)

--- a/src/routing_engine.py
+++ b/src/routing_engine.py
@@ -1,0 +1,26 @@
+"""Core logic for routing incoming signals to destinations."""
+
+from typing import Any, Dict
+
+
+class RoutingEngine:
+    """Simple routing engine placeholder."""
+
+    def __init__(self) -> None:
+        # mapping of input name to output address
+        self.routes: Dict[str, str] = {}
+
+    def add_route(self, source: str, destination: str) -> None:
+        """Register a mapping from a source signal to an OSC address."""
+        self.routes[source] = destination
+
+    def route(self, source: str, *payload: Any) -> None:
+        """Route the incoming payload if a mapping exists."""
+        dest = self.routes.get(source)
+        if dest:
+            from .osc_utils import OSCClient
+
+            client = OSCClient()
+            client.send(dest, *payload)
+        else:
+            print(f"No route for {source}")

--- a/src/stage_utils.py
+++ b/src/stage_utils.py
@@ -1,0 +1,16 @@
+"""Utilities for future stage modeling and projection mapping."""
+
+
+class Stage:
+    """Placeholder representation of a stage with basic geometry."""
+
+    def __init__(self, width: float = 10.0, depth: float = 5.0) -> None:
+        self.width = width
+        self.depth = depth
+
+    def area(self) -> float:
+        """Return the floor area of the stage."""
+        return self.width * self.depth
+
+    def __repr__(self) -> str:
+        return f"Stage(width={self.width}, depth={self.depth})"

--- a/src/ui_callbacks.py
+++ b/src/ui_callbacks.py
@@ -1,0 +1,13 @@
+"""Callbacks triggered by TouchDesigner UI components."""
+
+from typing import Any
+
+
+def on_button_press(name: str) -> None:
+    """Handle a generic button press."""
+    print(f"Button pressed: {name}")
+
+
+def on_dropdown_select(name: str, value: Any) -> None:
+    """Handle dropdown value changes."""
+    print(f"Dropdown '{name}' selected {value}")


### PR DESCRIPTION
## Summary
- implement simple placeholder functions/classes in `src` modules
- document stub usage in `src/README.md`

## Testing
- `python -m py_compile src/input_handlers.py src/osc_utils.py src/routing_engine.py src/ui_callbacks.py src/stage_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_686f59dfebcc83259234d0ceacf370c1