### PR TITLE
Fix ui helper and cleanup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,6 @@ project-root/
 └── .gitignore
 ```
 
-<<<<<<< HEAD
-<!-- Example configs live in `config/routing_map.json`, `config/input_aliases.json`, and `config/endpoints.json`. -->
-=======
 ## Getting Started
 
 1. **Clone & Open:**
@@ -60,4 +57,3 @@ project-root/
 ---
 
 **Keep this README up to date as the project evolves to ensure maximum clarity for both human collaborators and AI assistants.**
->>>>>>> main

--- a/src/scripts/osc_helpers.py
+++ b/src/scripts/osc_helpers.py
@@ -1,26 +1,16 @@
-
-import os, json
-
-# Load configuration files relative to this script
-BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-PATTERNS_FILE = os.path.join(BASE_DIR, 'osc_patterns.json')
-RESOLUME_FILE = os.path.join(BASE_DIR, 'resolume_mapping.json')
-LASER_FILE = os.path.join(BASE_DIR, 'laser_mapping.json')
-
-with open(PATTERNS_FILE) as f:
-    OSC_PATTERNS = json.load(f)
-with open(RESOLUME_FILE) as f:
-    RESOLUME_MAP = json.load(f)
-with open(LASER_FILE) as f:
-    LASER_MAP = json.load(f)
-
-def handle_outgoing(address, value):
-    out = op('osc_out')
-=======
+from __future__ import annotations
 import json
 import os
+from typing import Any, List
 
-# Resolve paths relative to this file
+# TouchDesigner provides a global `op` function for looking up operators.
+# When running outside of TD (e.g. unit tests or static analysis), that
+# function is missing, so supply a dummy fallback.
+if 'op' not in globals():  # pragma: no cover - used only for type checking
+    def op(_path):  # type: ignore
+        return None
+
+# Resolve paths relative to this script
 SRC_DIR = os.path.dirname(os.path.dirname(__file__))
 PATTERNS_PATH = os.path.join(SRC_DIR, 'osc_patterns.json')
 MAPPING_FILES = [
@@ -28,21 +18,19 @@ MAPPING_FILES = [
     os.path.join(SRC_DIR, 'laser_mapping.json'),
 ]
 
-_patterns = {}
-_mappings = {}
+_patterns: dict[str, Any] = {}
+_mappings: dict[str, Any] = {}
 
-def _read_json(path):
+def _read_json(path: str) -> dict:
     if not os.path.exists(path):
         return {}
     with open(path, 'r') as f:
         try:
             return json.load(f)
         except json.JSONDecodeError:
-            # Invalid JSON or empty file
             return {}
 
-
-def _load_configs():
+def _load_configs() -> None:
     """Load pattern routing rules and merge mapping files."""
     global _patterns, _mappings
     _patterns = _read_json(PATTERNS_PATH)
@@ -50,49 +38,28 @@ def _load_configs():
     for mf in MAPPING_FILES:
         _mappings.update(_read_json(mf))
 
-
 # Load configs on import
 _load_configs()
 
-
-def handle_outgoing(address, value):
+def handle_outgoing(address: str, value: Any) -> None:
     """Send an OSC message via the osc_out DAT."""
-    out = op('osc_out')  # get the outgoing OSC table operator
-
+    out = op('osc_out')
+    if not out:
+        return
     out.clear()
     out.appendRow([address, value])
     out.send()
 
-
-def handle_incoming(address, value):
-    """Translate generic OSC messages into target-specific addresses."""
-    messages = []
-    key = None
-    for name, pattern in OSC_PATTERNS.items():
-        if address == pattern:
-            key = name
-            break
-    if key is None:
-        return messages
-
-    if key in RESOLUME_MAP:
-        target = RESOLUME_MAP[key]
-        handle_outgoing(target, value)
-        messages.append(target)
-    if key in LASER_MAP:
-        target = LASER_MAP[key]
-        handle_outgoing(target, value)
-        messages.append(target)
-    return messages
-    """Map an incoming OSC address/value to one or more outgoing messages."""
-    # Obtain generic keys for this incoming address
+def handle_incoming(address: str, value: Any) -> List[str]:
+    """Translate a generic OSC address into target-specific messages."""
     generics = _patterns.get(address)
     if not generics:
-        return  # nothing mapped
+        return []
 
     if not isinstance(generics, list):
         generics = [generics]
 
+    sent: List[str] = []
     for key in generics:
         mapped = _mappings.get(key)
         if not mapped:
@@ -100,10 +67,12 @@ def handle_incoming(address, value):
         if isinstance(mapped, list):
             for dest in mapped:
                 handle_outgoing(dest, value)
+                sent.append(dest)
         else:
             handle_outgoing(mapped, value)
+            sent.append(mapped)
+    return sent
 
-
-def reload_mappings():
+def reload_mappings() -> None:
     """Public helper to reload JSON routing data at runtime."""
     _load_configs()

--- a/src/scripts/ui_helpers.py
+++ b/src/scripts/ui_helpers.py
@@ -1,4 +1,11 @@
-from typing import List, Union
+from typing import List
+
+# TouchDesigner defines a global `op` function for looking up operators. When
+# running this module outside of TD (e.g. during static analysis), that function
+# doesn't exist, so provide a no-op fallback to avoid NameError.
+if 'op' not in globals():  # pragma: no cover - used only for type checking
+    def op(_path):  # type: ignore
+        return None
 
 
 def _get_op(op_or_path):
@@ -52,4 +59,3 @@ def assemble_osc_address(layer_dd, channel_dd, index_field=None) -> str:
     if index_field is not None:
         parts.append(str(int(get_numeric_value(index_field))))
     return build_osc_address(parts)
-')


### PR DESCRIPTION
## Summary
- add fallback op function to ui_helpers
- clean up OSC helper module and strip merge markers
- sanitize README to remove leftover merge markers

## Testing
- `python3 -m py_compile src/scripts/ui_helpers.py`
- `python3 -m py_compile src/scripts/osc_helpers.py`
- `python3 -m py_compile src/scripts/*.py`

------
https://chatgpt.com/codex/tasks/task_e_686fd1f361f0832587fafeeb9c2a0ba3