### PR TITLE
Improve osc_in callback

### DIFF
--- a/src/DATs/README.md
+++ b/src/DATs/README.md
@@ -13,9 +13,9 @@ This folder holds all external Text DAT scripts used by **showcontrol.toe**. Eac
     osc_helpers.handle_incoming(address, value)
     ```
 
-- **`osc_in.py`** *(optional template)*
-  - Can be used to document or pre-populate settings for `/project1/osc_in_dat` (OSC In DAT)  
-  - Example content might include comments on port number, address filters, etc.
+- **`osc_in.py`**
+  - Callback for `/project1/osc_in_dat` (OSC In DAT)
+  - The default code prints the received OSC address and arguments to the Textport.
 
 - **`osc_out.py`**
   - Used by `/project1/osc_out_dat` (OSC Out DAT)  

--- a/src/DATs/osc_in.py
+++ b/src/DATs/osc_in.py
@@ -1,22 +1,36 @@
-# me - this DAT
-# 
-# dat - the DAT that received a message
-# rowIndex - the row number the message was placed into
-# message - an ascii representation of the data
-#           Unprintable characters and unicode characters will
-#           not be preserved. Use the 'byteData' parameter to get
-#           the raw bytes that were sent.
-# byteData - a byte array of the message.
-# timeStamp - the arrival time component the OSC message
-# address - the address component of the OSC message
-# args - a list of values contained within the OSC message
-# peer - a Peer object describing the originating message
-#   peer.close()    #close the connection
-#   peer.owner  #the operator to whom the peer belongs
-#   peer.address    #network address associated with the peer
-#   peer.port       #network port associated with the peer
-#
+"""OSC In DAT callback.
+
+This module defines :func:`onReceiveOSC`, which TouchDesigner calls
+whenever an OSC message arrives. The default implementation simply
+prints the address and arguments to the Textport. Modify it as needed
+for your project.
+"""
+
+# pylint: disable=invalid-name
 
 def onReceiveOSC(dat, rowIndex, message, byteData, timeStamp, address, args, peer):
-	return
-	
+    """Handle a received OSC message from the OSC In DAT.
+
+    Parameters
+    ----------
+    dat : DAT
+        The DAT that received the message.
+    rowIndex : int
+        Row index where the message was placed.
+    message : str
+        ASCII representation of the message.
+    byteData : bytes
+        Raw byte data of the message.
+    timeStamp : float
+        Arrival time of the OSC message.
+    address : str
+        OSC address of the message.
+    args : list
+        Values contained within the OSC message.
+    peer : object
+        Information about the sender.
+    """
+    # Access variables so they are not considered unused by linters
+    _ = (dat, rowIndex, message, byteData, timeStamp, peer)
+    print(f"Received OSC {address}: {args}")
+    return


### PR DESCRIPTION
## Summary
- flesh out `osc_in.py` so parameters are used and provide a helpful
  Textport log message
- update docs for the new callback behavior

## Testing
- `python -m py_compile src/DATs/osc_in.py`

------
https://chatgpt.com/codex/tasks/task_e_686fd454374483259bd1edae8ec41eda