### PR TITLE
Improve osc_exec_in validation

### DIFF
--- a/src/DATs/README.md
+++ b/src/DATs/README.md
@@ -5,8 +5,8 @@ This folder holds all external Text DAT scripts used by **showcontrol.toe**. Eac
 ## Files
 
 - **`osc_exec_in.py`**
-  - Attached to `/project1/dat_execute_in` (DAT Execute DAT)  
-  - Contains the `onTableChange(dat)` callback that reads OSC In DAT rows, extracts `address` and `value`, and calls:
+  - Attached to `/project1/dat_execute_in` (DAT Execute DAT)
+  - Contains the `onTableChange(dat)` callback that reads OSC In DAT rows, validates that column `1` contains a numeric value, and calls:
 
     ```python
     import osc_helpers

--- a/src/DATs/osc_exec_in.py
+++ b/src/DATs/osc_exec_in.py
@@ -9,9 +9,30 @@ import osc_helpers
 
 def onTableChange(dat):
     """Handle table changes by forwarding OSC messages via :mod:`osc_helpers`."""
+    # Skip the header row; each subsequent row should contain an OSC
+    # address in column 0 and a numeric value in column 1.
     for row in dat.rows()[1:]:
+        # Ensure the row has at least two cells before accessing them.
+        if len(row) < 2:
+            print("osc_exec_in: skipping row with missing columns", row)
+            continue
+
         address = row[0].val
-        value = float(row[1].val)
+        raw_value = row[1].val
+
+        # Try parsing the value as a float. TouchDesigner provides
+        # ``tdu.tryParse`` which returns ``None`` for invalid input.
+        value = None
+        if 'tdu' in globals() and hasattr(tdu, 'tryParse'):  # pragma: no cover
+            value = tdu.tryParse(raw_value)
+
+        if value is None:
+            try:
+                value = float(raw_value)
+            except (TypeError, ValueError):
+                print(f"osc_exec_in: invalid value '{raw_value}' for {address}")
+                continue
+
         osc_helpers.handle_incoming(address, value)
     return
 


### PR DESCRIPTION
## Summary
- guard against missing or non-numeric cells when parsing incoming rows
- use `tdu.tryParse` when available
- document new behavior in `src/DATs/README.md`

## Testing
- `python -m py_compile src/DATs/osc_exec_in.py`

------
https://chatgpt.com/codex/tasks/task_e_686fe70dad748325812ad754e7396722