### PR TITLE
Add send_via_dat helper for osc_out DAT

### DIFF
--- a/src/DATs/README.md
+++ b/src/DATs/README.md
@@ -19,7 +19,7 @@ This folder holds all external Text DAT scripts used by **showcontrol.toe**. Eac
 
 - **`osc_out.py`**
   - Used by `/project1/osc_out_dat` (OSC Out DAT)  
-  - Defines a helper snippet that writes `[address, value]` rows before sending, for example:
+  - Defines `send_via_dat` which writes `[address, value]` rows before sending:
 
     ```python
     def send_via_dat(address, value):

--- a/src/DATs/osc_out.py
+++ b/src/DATs/osc_out.py
@@ -1,0 +1,29 @@
+"""OSC Out helper functions for TouchDesigner.
+
+This module is loaded by ``/project1/osc_out_dat`` and provides a single
+:func:`send_via_dat` function to transmit OSC messages. The function clears the
+DAT, appends ``[address, value]`` and triggers ``send()`` so the message is
+immediately dispatched.
+"""
+
+# pylint: disable=undefined-variable
+
+from typing import Any
+
+
+def send_via_dat(address: str, value: Any) -> None:
+    """Send an OSC message using ``osc_out_dat``.
+
+    Parameters
+    ----------
+    address : str
+        Destination OSC address.
+    value : Any
+        Value to send with the message.
+    """
+    out_dat = op('osc_out_dat')
+    if not out_dat:
+        return
+    out_dat.clear()
+    out_dat.appendRow([address, value])
+    out_dat.send()


### PR DESCRIPTION
## Summary
- implement `send_via_dat` in `osc_out.py`
- document the helper in `src/DATs/README.md`

## Testing
- `pylint src/DATs/osc_out.py --score=y`

------
https://chatgpt.com/codex/tasks/task_e_686fe723d22483258c2a9e4c8b2fdb69