### PR TITLE
Update pylint settings in osc_in

### DIFF
--- a/src/DATs/osc_in.py
+++ b/src/DATs/osc_in.py
@@ -6,7 +6,7 @@ prints the address and arguments to the Textport. Modify it as needed
 for your project.
 """
 
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name,unused-argument
 
 def onReceiveOSC(dat, rowIndex, message, byteData, timeStamp, address, args, peer):
     """Handle a received OSC message from the OSC In DAT.


### PR DESCRIPTION
## Summary
- silence `unused-argument` warnings in `osc_in`

## Testing
- `pylint src/DATs/osc_in.py`

------
https://chatgpt.com/codex/tasks/task_e_686fe7431b9c832598d5a26d6d63727b