### PR TITLE
Update README with OSC context link

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ project-root/
 ```
 
 See [`TDCONTEXT.md`](TDCONTEXT.md) for an overview of TouchDesigner Python scripting.
+OSC address patterns for Resolume and Onyx are documented in [OSCCONTEXT.md](OSCCONTEXT.md).
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary
- add link to OSCCONTEXT.md documenting OSC address patterns for Resolume and Onyx

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ff9d463788325ac3afc95347ccd0f