### PR TITLE
Improve sub READMEs

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,4 +1,7 @@
 # CI/CD Workflows
 
-Contains GitHub Actions definitions (e.g., linting, tests).  
-Codex can ignore these unless updating automation.
+Contains GitHub Actions definitions used for linting and, when available,
+automated tests. These workflows help maintain the code‑first approach
+described in the repository root README by checking all Python scripts and
+JSON files on every pull request. Update the files in this directory whenever
+adding new checks or dependencies.

--- a/assets/README.md
+++ b/assets/README.md
@@ -8,4 +8,12 @@ Subfolders:
 - `images/` – UI mockups, stage reference shots, textures, and logos
 - `test_inputs/` – recorded signal files or dummy control sequences
 
+Device‑specific show files or example project files should live in their own
+subdirectories here. For instance, the root README describes building a
+standard Onyx show file with predetermined OSC and DMX endpoints. When that
+template is created, place it under `onyx_showfile_template/` so all
+collaborators can load the same configuration.
+
+No large binaries are included yet to keep the repository lightweight.
+
 <!-- Example configs live in `config/routing_map.json`, `config/input_aliases.json`, and `config/endpoints.json`. -->

--- a/src/DATs/README.md
+++ b/src/DATs/README.md
@@ -1,6 +1,10 @@
 # DATs Directory
 
-This folder holds all external Text DAT scripts used by **showcontrol.toe**. Each `.py` file here is loaded by a corresponding Text DAT in TouchDesigner with **“Keep in sync with external file”** enabled. Edit these files in VSCode and your changes will hot-reload in TD. See [`../../TDCONTEXT.md`](../../TDCONTEXT.md) for an overview of TouchDesigner Python scripting.
+This folder holds all external Text DAT scripts used by **showcontrol.toe**. Each
+`.py` file here is loaded by a corresponding Text DAT in TouchDesigner with
+**“Keep in sync with external file”** enabled. Edit these files in VS Code and
+your changes will hot‑reload in TD. See [`../../TDCONTEXT.md`](../../TDCONTEXT.md)
+for an overview of TouchDesigner Python scripting.
 
 ## Files
 
@@ -18,7 +22,7 @@ This folder holds all external Text DAT scripts used by **showcontrol.toe**. Eac
   - The default code prints the received OSC address and arguments to the Textport.
 
 - **`osc_out.py`**
-  - Used by `/project1/osc_out_dat` (OSC Out DAT)  
+  - Used by `/project1/osc_out_dat` (OSC Out DAT)
   - Defines `send_via_dat` which writes `[address, value]` rows before sending:
 
     ```python
@@ -27,6 +31,10 @@ This folder holds all external Text DAT scripts used by **showcontrol.toe**. Eac
         op('osc_out_dat').appendRow([address, value])
         op('osc_out_dat').send()
     ```
+- **`init_path.py`**
+  - Execute DAT that runs on project start.
+  - Adds the repository's `src/scripts` directory to `sys.path` so the other DAT
+    modules can import `routing_engine`, `osc_helpers`, and friends.
 
 ## Usage
 

--- a/src/README.md
+++ b/src/README.md
@@ -1,11 +1,20 @@
 # Source Configs & Scripts
 
-This folder holds:  
+This folder contains all source-controlled code and configuration referenced by
+the TouchDesigner project. The root README outlines the high-level philosophy of
+keeping logic in Python and JSON rather than buried inside `.toe` networks.
+Here you will find the modules and data that implement that approach.
+
+This folder holds:
 
 - `scripts/osc_helpers.py` – loads OSC patterns/mappings and sends messages.
 - `scripts/ui_helpers.py` – helper utilities for building addresses from UI selections.
 - `scripts/ui_builder.py` – constructs a small address-builder UI component within TouchDesigner.
 - `DATs/*.py` – callback scripts executed by TouchDesigner (see below).
+- `scripts/routing_engine.py` – wraps `osc_helpers` with a simple `route_message`
+  API for the rest of the project.
+- `scripts/address_generators.py` – utilities that produce large mapping tables
+  for Resolume and Onyx.
 
 <!-- Example configs live in `config/routing_map.json`, `config/input_aliases.json`, and `config/endpoints.json`. -->
 
@@ -19,6 +28,8 @@ This folder holds:
 - **osc_exec_in.py** → hooked into `/project1/dat_execute_in` DAT Execute DAT. It now exposes `send_from_ui()` so UI elements can trigger OSC messages directly.
 - **osc_in.py** → optional template for `/project1/osc_in_dat` OSC In DAT
 - **osc_out.py** → used by `/project1/scripts/osc_helpers.py` to send messages via OSC Out DAT
+- **init_path.py** → adds `src/scripts` to `sys.path` when the project starts so
+  all modules can be imported inside TouchDesigner.
 
 These `.py` files let you edit all your DAT logic in VSCode, then hot-reload in TD. Plain-text `.txt` versions work the same way if you prefer that extension.
 

--- a/src/scripts/README.md
+++ b/src/scripts/README.md
@@ -1,6 +1,8 @@
 # Python Helper Scripts
 
-All external Python code used by TouchDesigner lives here:
+All external Python code used by TouchDesigner lives here. These modules are
+imported by the Text DATs in `src/DATs/` and can also be executed outside of
+TouchDesigner for headless testing.
 
 - `osc_helpers.py` – loads routing JSON, maps incoming OSC messages, and sends
   them out again. The `handle_incoming(address, value)` function now accepts the
@@ -13,6 +15,10 @@ All external Python code used by TouchDesigner lives here:
   before forwarding the OSC data.
 - `ui_helpers.py` – build addresses from UI selections and expose helper
   functions.
+- `ui_builder.py` – convenience utilities that create a small address builder
+  COMP and wire its button to `osc_exec_in.send_from_ui()`.
+- `address_generators.py` – scripts that generate large mapping tables
+  (e.g. Resolume layers or Onyx playbacks) and write them to the JSON files.
 
 ## Function Overview
 
@@ -32,3 +38,15 @@ All external Python code used by TouchDesigner lives here:
 - **get_numeric_value(field)** – fetch a numeric value from a parameter or field COMP.
 - **build_osc_address(parts)** – join elements into a sanitized OSC address.
 - **assemble_osc_address(layer_dd, channel_dd, index_field=None)** – combine UI selections into `/layer/channel/index`.
+
+### ui_builder.py
+
+- **create_address_builder(parent, name='osc_address_builder')** – add a
+  ready-made UI component that assembles an OSC address and sends it through the
+  routing engine when its button is pressed.
+
+### address_generators.py
+
+- **generate_resolume_mapping(layers=4, clips_per_layer=4)** – produce a mapping
+  dictionary for Resolume addresses.
+- **generate_onyx_mapping(playbacks=20)** – produce an Onyx playback mapping.


### PR DESCRIPTION
## Summary
- expand `.github/workflows` details
- clarify purpose of assets folder
- document scripts and JSON mappings under `src/`
- list DAT scripts and their roles
- detail helper scripts used by TouchDesigner

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68703000b9ec8325ae410ec243493559