### PR TITLE
Add Python and OS-specific patterns to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Python bytecode
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Virtual environment directories
+env/
+.venv/
+venv/
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+
+# OS-specific files
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
## Summary
- ignore Python cache files, compiled artifacts, and virtual environments
- add ignores for common macOS and Windows files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68708fa94ff883259af95bcd271022d5