### PR TITLE
Add signal mapper utilities

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,5 @@
+"""ShowControl core package."""
+
+# Provide "mod" as an alias for this package to simplify imports
+import sys
+sys.modules.setdefault("mod", sys.modules[__name__])

--- a/src/scripts/README.md
+++ b/src/scripts/README.md
@@ -8,3 +8,15 @@ Examples:
 - Routing utilities
 
 Referenced across components via `mod.scripts.<module>`.
+
+## Using `signal_mapper`
+
+```python
+from mod.scripts import signal_mapper
+
+raw = {"note": 60, "velocity": 100}
+kind = signal_mapper.detect_signal_type(raw)  # 'midi'
+name, value = signal_mapper.normalize_signal(kind, raw["velocity"])
+address = signal_mapper.to_osc_address(name)
+```
+

--- a/src/scripts/signal_mapper.py
+++ b/src/scripts/signal_mapper.py
@@ -1,0 +1,91 @@
+"""Signal mapping utilities for ShowControl.
+
+This module offers helpers for detecting incoming signal types,
+normalizing their values to a 0–1 range, and mapping those
+normalized signals to OSC addresses. It is importable via
+``mod.scripts.signal_mapper``.
+"""
+
+from typing import Any, Tuple
+
+
+def detect_signal_type(data: Any) -> str:
+    """Return the detected signal type.
+
+    Parameters
+    ----------
+    data:
+        Raw data representing a signal. Can be a dict or any
+        structure from an input device.
+
+    Returns
+    -------
+    str
+        One of ``"midi"``, ``"osc"``, ``"dmx"``, or ``"unknown"``.
+    """
+    if isinstance(data, dict):
+        keys = set(data)
+        if {"address", "args"} <= keys:
+            return "osc"
+        if {"status", "data1", "data2"} <= keys or {"note", "velocity"} <= keys:
+            return "midi"
+        if {"universe", "channel", "value"} <= keys:
+            return "dmx"
+    if isinstance(data, (list, tuple)) and len(data) == 3:
+        if all(isinstance(x, int) and 0 <= x <= 255 for x in data):
+            return "dmx"
+    return "unknown"
+
+
+def normalize_signal(name: str, value: Any) -> Tuple[str, float]:
+    """Normalize a value to the range 0–1.
+
+    Parameters
+    ----------
+    name:
+        Name or type hint for the signal.
+    value:
+        Raw numeric value.
+
+    Returns
+    -------
+    tuple
+        ``(standardized_name, normalized_value)``
+    """
+    try:
+        value_f = float(value)
+    except (TypeError, ValueError):
+        return name.lower(), 0.0
+
+    lower = name.lower()
+    if lower in {"midi", "cc", "note"}:
+        value_f /= 127.0
+    elif lower == "dmx":
+        value_f /= 255.0
+    if value_f < 0:
+        value_f = 0.0
+    elif value_f > 1:
+        value_f = 1.0
+    return lower, value_f
+
+
+def to_osc_address(signal: Tuple[str, float] | str) -> str:
+    """Convert a signal name into an OSC address.
+
+    Parameters
+    ----------
+    signal:
+        Either a ``(name, value)`` tuple or the signal name alone.
+
+    Returns
+    -------
+    str
+        OSC address string beginning with ``/``.
+    """
+    name = signal[0] if isinstance(signal, tuple) else signal
+    if isinstance(name, int):
+        return f"/{name}"
+    name_str = str(name)
+    if not name_str.startswith("/"):
+        name_str = "/" + name_str.replace("_", "/")
+    return name_str

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,10 @@
+import sys
+from pathlib import Path
+
+# Ensure the src/ directory is on the path for tests
+SRC_PATH = Path(__file__).resolve().parents[1] / "src"
+if SRC_PATH.exists() and str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+# Import src so that it registers the 'mod' alias
+import src  # noqa: E402

--- a/tests/test_signal_mapper.py
+++ b/tests/test_signal_mapper.py
@@ -1,0 +1,20 @@
+import mod.scripts.signal_mapper as sm
+
+
+def test_detect_signal_type():
+    assert sm.detect_signal_type({'address': '/fader/1', 'args': [1]}) == 'osc'
+    assert sm.detect_signal_type({'note': 60, 'velocity': 100}) == 'midi'
+    assert sm.detect_signal_type({'universe': 1, 'channel': 1, 'value': 255}) == 'dmx'
+    assert sm.detect_signal_type('foo') == 'unknown'
+
+
+def test_normalize_signal():
+    assert sm.normalize_signal('midi', 64) == ('midi', 64/127)
+    assert sm.normalize_signal('dmx', 255) == ('dmx', 1.0)
+    assert sm.normalize_signal('custom', 0.5) == ('custom', 0.5)
+
+
+def test_to_osc_address():
+    assert sm.to_osc_address(('fader_1', 0.5)) == '/fader/1'
+    assert sm.to_osc_address('layer_1') == '/layer/1'
+


### PR DESCRIPTION
## Summary
- create `signal_mapper.py` utilities with detection, normalization, and OSC mapping helpers
- register `mod` alias in package `__init__`
- document example usage in `scripts/README.md`
- add tests and helper path setup for new module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870a3e1ef9083259936c8e61fdfb58a