### PR TITLE
Add OSC signal parsing and routing

### DIFF
--- a/src/router/README.md
+++ b/src/router/README.md
@@ -1,9 +1,20 @@
 # `router/` – Central Signal Hub
 
-Handles the normalized signal intake and dispatch. 
-This is the logic that receives named and normalized controls from all devices and routes them to their destinations.
+Handles the normalized signal intake and dispatch. This is the logic that
+receives named and normalized controls from all devices and routes them to
+their destinations.
 
-May include:
-- GUI handlers
-- Mapping logic
-- Routing configuration loaders
+The `osc_in_callbacks` module now leverages `signal_mapper` to interpret incoming
+OSC messages. Parsed signals are forwarded using `signal_router.dispatch` which
+will invoke a registered handler or log the value if no handler is present.
+
+Expected behavior:
+
+1. OSC addresses matching `/signal/<name>` with a numeric argument are
+   normalized to a 0–1 range.
+2. Messages with unknown addresses or unsupported types are logged and ignored.
+3. A custom handler may be registered via `signal_router.set_handler` to receive
+   `(name, value)` pairs for further routing.
+
+Additional modules in this folder may include GUI handlers, mapping logic, and
+routing configuration loaders.

--- a/src/router/osc_in_callbacks.py
+++ b/src/router/osc_in_callbacks.py
@@ -1,24 +1,29 @@
-#this is attatched to the OSC In DAT in the router component
+"""OSC input callbacks for the central router component."""
 
-# me - this DAT
-# 
-# dat - the DAT that received a message
-# rowIndex - the row number the message was placed into
-# message - an ascii representation of the data
-#           Unprintable characters and unicode characters will
-#           not be preserved. Use the 'byteData' parameter to get
-#           the raw bytes that were sent.
-# byteData - a byte array of the message.
-# timeStamp - the arrival time component the OSC message
-# address - the address component of the OSC message
-# args - a list of values contained within the OSC message
-# peer - a Peer object describing the originating message
-#   peer.close()    #close the connection
-#   peer.owner  #the operator to whom the peer belongs
-#   peer.address    #network address associated with the peer
-#   peer.port       #network port associated with the peer
-#
+import logging
+from typing import Any
 
-def onReceiveOSC(dat, rowIndex, message, byteData, timeStamp, address, args, peer):
-	return
-	
+from ..scripts import signal_mapper
+from .signal_router import dispatch
+
+LOGGER = logging.getLogger(__name__)
+
+
+def onReceiveOSC(dat: Any, rowIndex: int, message: str, byteData: bytes,
+                  timeStamp: float, address: str, args: list[Any], peer: Any) -> None:
+    """Handle incoming OSC messages from connected devices.
+
+    Parameters correspond to TouchDesigner's OSC In DAT callback signature.
+    The function normalizes incoming messages using :mod:`signal_mapper` and
+    dispatches them to the router. Unrecognized messages are logged.
+    """
+    try:
+        signal_name, value = signal_mapper.parse_osc_message(address, args)
+    except ValueError as exc:
+        LOGGER.warning("Ignored OSC message %s %s: %s", address, args, exc)
+        return
+
+    try:
+        dispatch(signal_name, value)
+    except Exception as exc:  # pragma: no cover - runtime safety
+        LOGGER.error("Failed to dispatch %s=%s: %s", signal_name, value, exc)

--- a/src/router/signal_router.py
+++ b/src/router/signal_router.py
@@ -1,0 +1,27 @@
+"""Simple router dispatcher for normalized signals."""
+
+import logging
+from typing import Callable
+
+LOGGER = logging.getLogger(__name__)
+
+# Global handler; in real TouchDesigner environment this would be replaced
+_HANDLER: Callable[[str, float], None] | None = None
+
+
+def set_handler(handler: Callable[[str, float], None]) -> None:
+    """Register a handler for incoming normalized signals."""
+    global _HANDLER
+    _HANDLER = handler
+    LOGGER.debug("Router handler set to %s", handler)
+
+
+def dispatch(signal_name: str, value: float) -> None:
+    """Send a signal to the registered handler or log if none is set."""
+    if _HANDLER is not None:
+        try:
+            _HANDLER(signal_name, value)
+        except Exception as exc:  # pragma: no cover - best effort logging
+            LOGGER.error("Error in router handler for %s: %s", signal_name, exc)
+    else:
+        LOGGER.info("Signal %s=%f (no handler)", signal_name, value)

--- a/src/scripts/signal_mapper.py
+++ b/src/scripts/signal_mapper.py
@@ -1,0 +1,53 @@
+"""Utilities for interpreting raw OSC messages into normalized signal data.
+"""
+
+import logging
+from typing import Any, Tuple
+
+LOGGER = logging.getLogger(__name__)
+
+
+def parse_osc_message(address: str, args: list[Any]) -> Tuple[str, float]:
+    """Parse an OSC address and arguments into a normalized signal.
+
+    Parameters
+    ----------
+    address: str
+        OSC address like ``/signal/fader1``.
+    args: list
+        Arguments from the OSC packet.
+
+    Returns
+    -------
+    Tuple[str, float]
+        ``(signal_name, normalized_value)``.
+
+    Raises
+    ------
+    ValueError
+        If the address or arguments cannot be interpreted.
+    """
+    if not address.startswith("/signal/"):
+        raise ValueError(f"Unhandled address: {address}")
+
+    if not args:
+        raise ValueError("Missing value in OSC args")
+
+    name = address.split("/", 2)[-1]
+    value = args[0]
+
+    # Normalize numeric values to 0-1 range
+    if isinstance(value, (int, float)):
+        if 0 <= value <= 1:
+            norm = float(value)
+        elif 0 <= value <= 127:
+            norm = float(value) / 127
+        elif 0 <= value <= 255:
+            norm = float(value) / 255
+        else:
+            raise ValueError(f"Unsupported numeric range for {value}")
+    else:
+        raise ValueError(f"Unsupported value type: {type(value)!r}")
+
+    LOGGER.debug("Parsed OSC %s %s -> %s:%f", address, args, name, norm)
+    return name, norm


### PR DESCRIPTION
## Summary
- route OSC input through signal_mapper into a dispatch handler
- add simple signal_mapper utilities for OSC parsing
- provide a signal_router dispatcher utility
- document new behavior in router README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870a5531b9c832587a0b6af4b87c6ab